### PR TITLE
When navigating up from compose, go back to the same instance of

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -55,7 +55,8 @@
         <!-- Timeline -->
         <activity
             android:name=".activities.TimelineActivity"
-            android:label="@string/title_activity_timeline" >
+            android:label="@string/title_activity_timeline"
+            android:launchMode="singleTop">
         </activity>
         <activity
             android:name=".activities.ComposeActivity"

--- a/app/src/main/java/com/codepath/apps/simpletwitterclient/activities/ComposeActivity.java
+++ b/app/src/main/java/com/codepath/apps/simpletwitterclient/activities/ComposeActivity.java
@@ -2,6 +2,7 @@ package com.codepath.apps.simpletwitterclient.activities;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.v4.app.NavUtils;
 import android.support.v7.app.ActionBarActivity;
 import android.support.v7.internal.view.menu.ActionMenuItemView;
 import android.text.Editable;
@@ -78,6 +79,14 @@ public class ComposeActivity extends ActionBarActivity {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
+
+        switch (item.getItemId()) {
+            // Respond to Up navigation. Return to previous TimelineActivity state
+            case android.R.id.home:
+                NavUtils.navigateUpFromSameTask(this);
+                return true;
+        }
+
         return super.onOptionsItemSelected(item);
     }
 

--- a/app/src/main/java/com/codepath/apps/simpletwitterclient/activities/TimelineActivity.java
+++ b/app/src/main/java/com/codepath/apps/simpletwitterclient/activities/TimelineActivity.java
@@ -38,9 +38,6 @@ public class TimelineActivity extends ActionBarActivity {
         //attach the tabstrip to the viewpager
         tabStrip.setViewPager(vpPager);
 
-
-
-
         // Access the fragment (from layout)
 //        if (savedInstanceState == null) {
 //            fragmentTweetsList = (TweetsListFragment) getSupportFragmentManager().findFragmentById(R.id.fragment_timeline);
@@ -52,7 +49,6 @@ public class TimelineActivity extends ActionBarActivity {
         //setUpPullToRefresh();
 
     }
-
 
 
     @Override

--- a/app/src/main/java/com/codepath/apps/simpletwitterclient/networking/TwitterClient.java
+++ b/app/src/main/java/com/codepath/apps/simpletwitterclient/networking/TwitterClient.java
@@ -2,7 +2,6 @@ package com.codepath.apps.simpletwitterclient.networking;
 
 import android.content.Context;
 
-import com.codepath.apps.simpletwitterclient.lib.Logger;
 import com.codepath.oauth.OAuthBaseClient;
 import com.loopj.android.http.AsyncHttpResponseHandler;
 import com.loopj.android.http.RequestParams;
@@ -81,8 +80,6 @@ url: GET statuses/home_timeline.json
     }
 
     public void getMentionsTimeline(AsyncHttpResponseHandler handler) {
-
-        Logger.log(TAG, "getting mentions");
 
         String apiUrl = getApiUrl("statuses/mentions_timeline.json");
 


### PR DESCRIPTION
the timeline activity. This makes it so the timeline activity does
not reload when navigating up to it.
